### PR TITLE
[FIX] argentina-sale: AR multi-company fixes

### DIFF
--- a/l10n_ar_sale/__manifest__.py
+++ b/l10n_ar_sale/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Argentinian Sale Total Fields",
-    "version": "19.0.1.5.1",
+    "version": "19.0.1.5.2",
     "category": "Localization/Argentina",
     "sequence": 14,
     "author": "ADHOC SA",

--- a/l10n_ar_sale/__manifest__.py
+++ b/l10n_ar_sale/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Argentinian Sale Total Fields",
-    "version": "19.0.1.5.0",
+    "version": "19.0.1.5.1",
     "category": "Localization/Argentina",
     "sequence": 14,
     "author": "ADHOC SA",

--- a/l10n_ar_sale/models/sale_order.py
+++ b/l10n_ar_sale/models/sale_order.py
@@ -15,6 +15,10 @@ class SaleOrder(models.Model):
     vat_discriminated = fields.Boolean(
         compute="_compute_vat_discriminated",
     )
+    # Related used to show/hide AR-specific fields in views (multi-company gating)
+    l10n_ar_company_requires_vat = fields.Boolean(
+        related="company_id.l10n_ar_company_requires_vat",
+    )
 
     @api.depends(
         "partner_id.l10n_ar_afip_responsibility_type_id",
@@ -37,7 +41,8 @@ class SaleOrder(models.Model):
         if not report_or_portal_view:
             return
 
-        for order in self.filtered(lambda x: not x.vat_discriminated):
+        # Multi-company gating: only adjust totals of Argentinean companies
+        for order in self.filtered(lambda x: x.company_id.country_code == "AR" and not x.vat_discriminated):
             tax_groups = order.order_line.mapped("tax_ids.tax_group_id")
             if not tax_groups:
                 continue
@@ -139,7 +144,8 @@ class SaleOrder(models.Model):
         """
         for rec in self.filtered(
             lambda x: (
-                x.fiscal_position_id.l10n_ar_tax_ids.filtered(lambda x: x.tax_type == "perception")
+                x.company_id.country_code == "AR"
+                and x.fiscal_position_id.l10n_ar_tax_ids.filtered(lambda x: x.tax_type == "perception")
                 and x.state not in ["cancel", "sale"]
             )
         ):
@@ -158,7 +164,9 @@ class SaleOrder(models.Model):
         que no incluye las percepciones argentinas (almacenadas en l10n_ar_tax_ids).
         Luego de crear la línea de envío, agregamos las percepciones correspondientes."""
         line = super()._create_delivery_line(carrier, price_unit)
-        if self.fiscal_position_id.l10n_ar_tax_ids.filtered(lambda x: x.tax_type == "perception"):
+        if self.company_id.country_code == "AR" and self.fiscal_position_id.l10n_ar_tax_ids.filtered(
+            lambda x: x.tax_type == "perception"
+        ):
             date = fields.Date.to_date(fields.Datetime.context_timestamp(self, self.date_order))
             new_taxes = self.fiscal_position_id._l10n_ar_add_taxes(self.partner_id, self.company_id, date, "perception")
             if new_taxes:

--- a/l10n_ar_sale/models/sale_order.py
+++ b/l10n_ar_sale/models/sale_order.py
@@ -52,6 +52,13 @@ class SaleOrder(models.Model):
             updated_tax_group_vals = list(filter(lambda x: x.get("id") not in to_remove_ids, tax_group_vals))
             order.tax_totals["subtotals"][0]["tax_groups"] = updated_tax_group_vals
 
+    def _get_name_tax_totals_view(self):
+        """Select the AR totals template only for Argentinean sale orders."""
+        self.ensure_one()
+        if self.company_id.country_code == "AR":
+            return "l10n_ar_sale.document_tax_totals"
+        return super()._get_name_tax_totals_view()
+
     def _get_name_sale_report(self, report_xml_id):
         """Method similar to the '_get_name_invoice_report' of l10n_latam_invoice_document
         Basically it allows different localizations to define it's own report
@@ -170,7 +177,7 @@ class SaleOrder(models.Model):
             date = fields.Date.to_date(fields.Datetime.context_timestamp(self, self.date_order))
             new_taxes = self.fiscal_position_id._l10n_ar_add_taxes(self.partner_id, self.company_id, date, "perception")
             if new_taxes:
-                line.tax_id = line.tax_id | new_taxes
+                line.tax_ids |= new_taxes
         return line
 
     def copy(self, default=None):

--- a/l10n_ar_sale/models/sale_order_line.py
+++ b/l10n_ar_sale/models/sale_order_line.py
@@ -168,9 +168,12 @@ class SaleOrderLine(models.Model):
         """Agregado de taxes de modulo l10n_ar_tax segun fiscal position"""
         super()._compute_tax_ids()
 
-        for rec in self.with_context(tz="America/Argentina/Buenos_Aires").filtered(
-            "order_id.fiscal_position_id.l10n_ar_tax_ids"
-        ):
+        # Multi-company gating: only lines of Argentinean companies whose fiscal
+        # position has AR perception taxes configured
+        ar_lines = self.filtered(
+            lambda rec: rec.company_id.country_code == "AR" and rec.order_id.fiscal_position_id.l10n_ar_tax_ids
+        )
+        for rec in ar_lines.with_context(tz="America/Argentina/Buenos_Aires"):
             date = fields.Date.to_date(fields.Datetime.context_timestamp(rec, rec.order_id.date_order))
             rec.tax_ids += rec.order_id.fiscal_position_id._l10n_ar_add_taxes(
                 rec.order_partner_id, rec.company_id, date, "perception"

--- a/l10n_ar_sale/views/l10n_ar_sale_templates.xml
+++ b/l10n_ar_sale/views/l10n_ar_sale_templates.xml
@@ -12,13 +12,11 @@
             <attribute name="t-out">', '.join(map(lambda x: (x.invoice_label or x.name), line.report_tax_id))</attribute>
         </xpath>
 
-
-        <!-- use column vat instead of taxes and only if vat discriminated.
-             Multi-company: never replace shared core nodes. The core Taxes column
-             stays untouched for non-AR companies; it is hidden only for Argentinean
-             companies, where the custom "% VAT" column is shown instead when the
-             order discriminates VAT. -->
-
+        <!--
+            Keep shared Odoo nodes intact. Non-AR companies keep the standard Taxes
+            column; AR orders replace its display with the custom % VAT column only
+            when VAT is discriminated.
+        -->
         <xpath expr="//th[@id='taxes_header']" position="attributes">
             <attribute name="t-if">display_taxes and sale_order.company_id.country_code != 'AR'</attribute>
         </xpath>
@@ -26,17 +24,38 @@
             <th t-if="sale_order.company_id.country_code == 'AR' and sale_order.vat_discriminated" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}" id="l10n_ar_taxes_header"><span>% VAT</span></th>
         </xpath>
 
-        <!-- use column vat instead of taxes and only list vat taxes -->
+        <!-- Product rows: hide the core tax cell only for AR and add the VAT cell. -->
         <xpath expr="//td[@name='td_product_taxes']" position="attributes">
-            <attribute name="t-if">display_taxes and sale_order.company_id.country_code != 'AR'</attribute>
-        </xpath>
-        <xpath expr="//td[@name='td_combo_taxes']" position="attributes">
             <attribute name="t-if">display_taxes and sale_order.company_id.country_code != 'AR'</attribute>
         </xpath>
         <xpath expr="//td[@name='td_product_taxes']" position="after">
             <td t-if="sale_order.company_id.country_code == 'AR' and sale_order.vat_discriminated" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}" id="l10n_ar_taxes">
                 <span t-out="', '.join(map(lambda x: (x.invoice_label or x.name), line.tax_ids.filtered(lambda x: x.tax_group_id.l10n_ar_vat_afip_code)))"/>
             </td>
+        </xpath>
+
+        <!--
+            Combo and collapsed-section rows do not expose tax records in the same
+            shape as ordinary product rows. Add an AR-only placeholder cell so their
+            subtotal stays aligned with the % VAT header without displaying
+            perceptions as VAT.
+        -->
+        <xpath expr="//td[@name='td_combo_taxes']" position="attributes">
+            <attribute name="t-if">display_taxes and sale_order.company_id.country_code != 'AR'</attribute>
+        </xpath>
+        <xpath expr="//td[@name='td_combo_taxes']" position="after">
+            <td t-if="sale_order.company_id.country_code == 'AR' and sale_order.vat_discriminated" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}" name="td_l10n_ar_combo_taxes"/>
+        </xpath>
+        <xpath expr="//td[@name='td_section_group_taxes']" position="attributes">
+            <attribute name="t-if">display_taxes and sale_order.company_id.country_code != 'AR'</attribute>
+        </xpath>
+        <xpath expr="//td[@name='td_section_group_taxes']" position="after">
+            <td t-if="sale_order.company_id.country_code == 'AR' and sale_order.vat_discriminated" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}" name="td_l10n_ar_section_group_taxes"/>
+        </xpath>
+
+        <!-- Section headers must span the columns actually rendered above. -->
+        <xpath expr="//t[@t-set='section_name_colspan']" position="attributes">
+            <attribute name="t-value">3 + (1 if display_discount else 0) + (1 if display_taxes and (sale_order.company_id.country_code != 'AR' or sale_order.vat_discriminated) else 0)</attribute>
         </xpath>
 
     </template>

--- a/l10n_ar_sale/views/l10n_ar_sale_templates.xml
+++ b/l10n_ar_sale/views/l10n_ar_sale_templates.xml
@@ -13,17 +13,31 @@
         </xpath>
 
 
-        <!-- use column vat instead of taxes and only if vat discriminated -->
+        <!-- use column vat instead of taxes and only if vat discriminated.
+             Multi-company: never replace shared core nodes. The core Taxes column
+             stays untouched for non-AR companies; it is hidden only for Argentinean
+             companies, where the custom "% VAT" column is shown instead when the
+             order discriminates VAT. -->
 
-        <th t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}" position="replace">
-            <th id="taxes_header" t-if="sale_order.vat_discriminated" t-attf-class="text-right {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}"><span>% VAT</span></th>
-        </th>
-        <!-- use column vat instead of taxes and only list vat taxes-->
-        <td t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}" position="replace">
-            <td id="taxes" t-if="sale_order.vat_discriminated" t-attf-class="text-right {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
+        <xpath expr="//th[@id='taxes_header']" position="attributes">
+            <attribute name="t-if">display_taxes and sale_order.company_id.country_code != 'AR'</attribute>
+        </xpath>
+        <xpath expr="//th[@id='taxes_header']" position="after">
+            <th t-if="sale_order.company_id.country_code == 'AR' and sale_order.vat_discriminated" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}" id="l10n_ar_taxes_header"><span>% VAT</span></th>
+        </xpath>
+
+        <!-- use column vat instead of taxes and only list vat taxes -->
+        <xpath expr="//td[@name='td_product_taxes']" position="attributes">
+            <attribute name="t-if">display_taxes and sale_order.company_id.country_code != 'AR'</attribute>
+        </xpath>
+        <xpath expr="//td[@name='td_combo_taxes']" position="attributes">
+            <attribute name="t-if">display_taxes and sale_order.company_id.country_code != 'AR'</attribute>
+        </xpath>
+        <xpath expr="//td[@name='td_product_taxes']" position="after">
+            <td t-if="sale_order.company_id.country_code == 'AR' and sale_order.vat_discriminated" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}" id="l10n_ar_taxes">
                 <span t-out="', '.join(map(lambda x: (x.invoice_label or x.name), line.tax_ids.filtered(lambda x: x.tax_group_id.l10n_ar_vat_afip_code)))"/>
             </td>
-        </td>
+        </xpath>
 
     </template>
 

--- a/l10n_ar_sale/views/sale_view.xml
+++ b/l10n_ar_sale/views/sale_view.xml
@@ -6,7 +6,8 @@
         <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="arch" type="xml">
             <group name="sale_info">
-                <field name="vat_discriminated"/>
+                <field name="l10n_ar_company_requires_vat" invisible="1"/>
+                <field name="vat_discriminated" invisible="not l10n_ar_company_requires_vat"/>
             </group>
             <xpath expr="//field[@name='order_line']/list//field[@name='tax_ids']" position="after">
                 <field name="price_unit_with_tax" groups="l10n_ar_sale.sale_price_unit_with_tax" widget="monetary"/>

--- a/l10n_ar_stock_delivery/__manifest__.py
+++ b/l10n_ar_stock_delivery/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Integracion entre modulo delivery y localización argentina",
-    "version": "19.0.1.1.0",
+    "version": "19.0.1.1.1",
     "category": "Localization/Argentina",
     "sequence": 14,
     "author": "ADHOC SA",
@@ -12,6 +12,7 @@
     ],
     "demo": [],
     "installable": True,
-    "auto_install": True,
+    # Multi-company: never auto-install database-wide; install explicitly where needed.
+    "auto_install": False,
     "application": False,
 }


### PR DESCRIPTION
## Scope

Draft remediation PR for the `argentina-sale` pilot, covering the applicable findings from the v19 multi-company audit.

## Implemented changes

### `l10n_ar_sale`

- Non-Argentine companies retain Odoo's standard portal tax column and totals template.
- Argentine sale orders with VAT discrimination display the custom `% VAT` portal column instead of the standard tax column.
- The portal table handles ordinary product rows, combo rows, and collapsed section/subsection summaries while preserving column alignment.
- `sale.order._get_name_tax_totals_view()` selects `l10n_ar_sale.document_tax_totals` only for Argentine companies. Other companies retain the standard template through `super()`.
- The reviewed AR-specific tax-total, fiscal-position perception, delivery, copy, and tax-computation behavior is limited to Argentine companies where applicable.
- Delivery-line perceptions are added through the Odoo 19 `sale.order.line.tax_ids` field.
- Module version: `19.0.1.5.2`.

### `l10n_ar_stock_delivery`

- `auto_install` is set to `False` to prevent implicit installation through dependencies in the shared database.
- Module version: `19.0.1.1.1`.

## Static checks performed

- Read the complete `v19_code_review.md` audit and reviewed the in-scope `argentina-sale` findings.
- Performed a static review of the final diff and source code.
- Compared the implementation against the vendored Odoo 19 source code for:
  - `sale.order._get_name_tax_totals_view()` and the portal's dynamic totals-template call;
  - `sale.order.line.tax_ids` and delivery-line creation;
  - portal nodes for standard product rows, combo rows, grouped section rows, and section-header colspan.
- Confirmed statically that `l10n_ar_sale_templates.xml` contains no `position="replace"` directives.
- Confirmed statically that the delivery path uses `line.tax_ids`, not `line.tax_id`.
- The associated action review passed.

## Not executed

No tests were run on an Odoo instance. No module installation or upgrade, portal rendering, PDF/pro-forma generation, delivery/perception scenario, or automated Odoo test suite was executed. This project currently has no configured Odoo instance for those validations.

## Functional validation still required

1. Install or upgrade the modules and their declared dependencies on an Odoo 19 instance.
2. Validate a taxed quotation for a non-AR company: standard portal and PDF behavior.
3. Validate an AR quotation with VAT discrimination: `% VAT` portal column and AR totals in portal and PDF.
4. Validate an AR quotation without VAT discrimination: no empty tax column and expected totals behavior.
5. Validate an AR quotation containing a combo, collapsed section/subsection, and discount: correct table alignment.
6. Add delivery to an AR quotation with a fiscal position that applies perceptions: successful delivery-line creation and expected `tax_ids`.
7. Duplicate and modify AR and non-AR quotations: AR recomputation only where applicable.
8. Verify that `l10n_ar_stock_delivery` does not auto-install with its dependencies and can be installed explicitly.

This PR remains a draft pending functional validation and BTL review.